### PR TITLE
Fix ruby 2.3 depreciation warning

### DIFF
--- a/lib/babel_bridge/nodes/rule_node.rb
+++ b/lib/babel_bridge/nodes/rule_node.rb
@@ -76,7 +76,7 @@ class RuleNode < NonTerminalNode
     nil
   end
 
-  def respond_to?(method_name)
+  def respond_to?(method_name, include_all = false)
     super ||
     matches_by_name[method_name] ||
     forward_to(method_name)


### PR DESCRIPTION
Changes responsd_to? definition to take 2 args.